### PR TITLE
Updating go.mod to point to voprf-poc repository.

### DIFF
--- a/go/client/client.go
+++ b/go/client/client.go
@@ -11,10 +11,10 @@ import (
 	"math/big"
 	"net/http"
 
-	"github.com/alxdavids/oprf-poc/go/jsonrpc"
-	"github.com/alxdavids/oprf-poc/go/oprf"
-	gg "github.com/alxdavids/oprf-poc/go/oprf/groups"
-	"github.com/alxdavids/oprf-poc/go/oprf/groups/dleq"
+	"github.com/alxdavids/voprf-poc/go/jsonrpc"
+	"github.com/alxdavids/voprf-poc/go/oprf"
+	gg "github.com/alxdavids/voprf-poc/go/oprf/groups"
+	"github.com/alxdavids/voprf-poc/go/oprf/groups/dleq"
 )
 
 var (

--- a/go/client/client_test.go
+++ b/go/client/client_test.go
@@ -7,10 +7,10 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/alxdavids/oprf-poc/go/jsonrpc"
-	"github.com/alxdavids/oprf-poc/go/oerr"
-	gg "github.com/alxdavids/oprf-poc/go/oprf/groups"
-	"github.com/alxdavids/oprf-poc/go/oprf/groups/ecgroup"
+	"github.com/alxdavids/voprf-poc/go/jsonrpc"
+	"github.com/alxdavids/voprf-poc/go/oerr"
+	gg "github.com/alxdavids/voprf-poc/go/oprf/groups"
+	"github.com/alxdavids/voprf-poc/go/oprf/groups/ecgroup"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/go/go.mod
+++ b/go/go.mod
@@ -1,4 +1,4 @@
-module github.com/alxdavids/oprf-poc/go
+module github.com/alxdavids/voprf-poc/go
 
 go 1.13
 

--- a/go/go.sum
+++ b/go/go.sum
@@ -16,7 +16,6 @@ golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190602015325-4c4f7f33c9ed h1:uPxWBzB3+mlnjy9W58qY1j/cjyFjutgw/Vhan2zLy/A=
 golang.org/x/sys v0.0.0-20190602015325-4c4f7f33c9ed/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
-gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/go/jsonrpc/jsonrpc.go
+++ b/go/jsonrpc/jsonrpc.go
@@ -1,6 +1,6 @@
 package jsonrpc
 
-import "github.com/alxdavids/oprf-poc/go/oerr"
+import "github.com/alxdavids/voprf-poc/go/oerr"
 
 // Request describes the structure of a JSONRPC request
 type Request struct {

--- a/go/main.go
+++ b/go/main.go
@@ -6,9 +6,9 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/alxdavids/oprf-poc/go/client"
-	"github.com/alxdavids/oprf-poc/go/oprf/groups/ecgroup"
-	"github.com/alxdavids/oprf-poc/go/server"
+	"github.com/alxdavids/voprf-poc/go/client"
+	"github.com/alxdavids/voprf-poc/go/oprf/groups/ecgroup"
+	"github.com/alxdavids/voprf-poc/go/server"
 )
 
 var (

--- a/go/oprf/groups/dleq/dleq.go
+++ b/go/oprf/groups/dleq/dleq.go
@@ -4,10 +4,10 @@ import (
 	"hash"
 	"math/big"
 
-	"github.com/alxdavids/oprf-poc/go/oerr"
-	gg "github.com/alxdavids/oprf-poc/go/oprf/groups"
-	"github.com/alxdavids/oprf-poc/go/oprf/groups/ecgroup"
-	"github.com/alxdavids/oprf-poc/go/oprf/utils"
+	"github.com/alxdavids/voprf-poc/go/oerr"
+	gg "github.com/alxdavids/voprf-poc/go/oprf/groups"
+	"github.com/alxdavids/voprf-poc/go/oprf/groups/ecgroup"
+	"github.com/alxdavids/voprf-poc/go/oprf/utils"
 )
 
 // Proof corresponds to the DLEQ proof object that is used to prove that the

--- a/go/oprf/groups/dleq/dleq_test.go
+++ b/go/oprf/groups/dleq/dleq_test.go
@@ -6,10 +6,10 @@ import (
 	"math/big"
 	"testing"
 
-	"github.com/alxdavids/oprf-poc/go/oerr"
-	gg "github.com/alxdavids/oprf-poc/go/oprf/groups"
-	"github.com/alxdavids/oprf-poc/go/oprf/groups/ecgroup"
-	"github.com/alxdavids/oprf-poc/go/oprf/utils"
+	"github.com/alxdavids/voprf-poc/go/oerr"
+	gg "github.com/alxdavids/voprf-poc/go/oprf/groups"
+	"github.com/alxdavids/voprf-poc/go/oprf/groups/ecgroup"
+	"github.com/alxdavids/voprf-poc/go/oprf/utils"
 )
 
 func TestValidDLEQP384(t *testing.T) {

--- a/go/oprf/groups/ecgroup/ec.go
+++ b/go/oprf/groups/ecgroup/ec.go
@@ -9,10 +9,10 @@ import (
 	"io"
 	"math/big"
 
-	"github.com/alxdavids/oprf-poc/go/oerr"
-	gg "github.com/alxdavids/oprf-poc/go/oprf/groups"
-	"github.com/alxdavids/oprf-poc/go/oprf/utils"
-	"github.com/alxdavids/oprf-poc/go/oprf/utils/constants"
+	"github.com/alxdavids/voprf-poc/go/oerr"
+	gg "github.com/alxdavids/voprf-poc/go/oprf/groups"
+	"github.com/alxdavids/voprf-poc/go/oprf/utils"
+	"github.com/alxdavids/voprf-poc/go/oprf/utils/constants"
 	"github.com/cloudflare/circl/ecc/p384"
 )
 

--- a/go/oprf/groups/ecgroup/ec_test.go
+++ b/go/oprf/groups/ecgroup/ec_test.go
@@ -10,10 +10,10 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/alxdavids/oprf-poc/go/oerr"
-	gg "github.com/alxdavids/oprf-poc/go/oprf/groups"
-	"github.com/alxdavids/oprf-poc/go/oprf/utils"
-	"github.com/alxdavids/oprf-poc/go/oprf/utils/constants"
+	"github.com/alxdavids/voprf-poc/go/oerr"
+	gg "github.com/alxdavids/voprf-poc/go/oprf/groups"
+	"github.com/alxdavids/voprf-poc/go/oprf/utils"
+	"github.com/alxdavids/voprf-poc/go/oprf/utils/constants"
 	"github.com/cloudflare/circl/ecc/p384"
 	"github.com/stretchr/testify/assert"
 )

--- a/go/oprf/groups/ecgroup/h2c.go
+++ b/go/oprf/groups/ecgroup/h2c.go
@@ -5,9 +5,9 @@ import (
 	"hash"
 	"math/big"
 
-	"github.com/alxdavids/oprf-poc/go/oerr"
-	"github.com/alxdavids/oprf-poc/go/oprf/utils"
-	"github.com/alxdavids/oprf-poc/go/oprf/utils/constants"
+	"github.com/alxdavids/voprf-poc/go/oerr"
+	"github.com/alxdavids/voprf-poc/go/oprf/utils"
+	"github.com/alxdavids/voprf-poc/go/oprf/utils/constants"
 )
 
 // h2cParams contains all of the parameters required for computing the

--- a/go/oprf/groups/ecgroup/h2c_test.go
+++ b/go/oprf/groups/ecgroup/h2c_test.go
@@ -8,7 +8,7 @@ import (
 	"math/big"
 	"testing"
 
-	"github.com/alxdavids/oprf-poc/go/oprf/utils"
+	"github.com/alxdavids/voprf-poc/go/oprf/utils"
 	"github.com/cloudflare/circl/ecc/p384"
 )
 

--- a/go/oprf/groups/group.go
+++ b/go/oprf/groups/group.go
@@ -8,8 +8,8 @@ import (
 	"reflect"
 	"strings"
 
-	"github.com/alxdavids/oprf-poc/go/oerr"
-	"github.com/alxdavids/oprf-poc/go/oprf/utils"
+	"github.com/alxdavids/voprf-poc/go/oerr"
+	"github.com/alxdavids/voprf-poc/go/oprf/utils"
 )
 
 // Ciphersuite corresponds to the OPRF ciphersuite that is chosen. The

--- a/go/oprf/oprf.go
+++ b/go/oprf/oprf.go
@@ -5,9 +5,9 @@ import (
 	"encoding/json"
 	"math/big"
 
-	"github.com/alxdavids/oprf-poc/go/oerr"
-	gg "github.com/alxdavids/oprf-poc/go/oprf/groups"
-	"github.com/alxdavids/oprf-poc/go/oprf/groups/dleq"
+	"github.com/alxdavids/voprf-poc/go/oerr"
+	gg "github.com/alxdavids/voprf-poc/go/oprf/groups"
+	"github.com/alxdavids/voprf-poc/go/oprf/groups/dleq"
 )
 
 // PublicKey represents a commitment to a given secret key that is made public

--- a/go/oprf/oprf_test.go
+++ b/go/oprf/oprf_test.go
@@ -7,9 +7,9 @@ import (
 	"math/big"
 	"testing"
 
-	"github.com/alxdavids/oprf-poc/go/oerr"
-	gg "github.com/alxdavids/oprf-poc/go/oprf/groups"
-	"github.com/alxdavids/oprf-poc/go/oprf/groups/ecgroup"
+	"github.com/alxdavids/voprf-poc/go/oerr"
+	gg "github.com/alxdavids/voprf-poc/go/oprf/groups"
+	"github.com/alxdavids/voprf-poc/go/oprf/groups/ecgroup"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/go/oprf/utils/comparison.go
+++ b/go/oprf/utils/comparison.go
@@ -3,7 +3,7 @@ package utils
 import (
 	"math/big"
 
-	"github.com/alxdavids/oprf-poc/go/oprf/utils/constants"
+	"github.com/alxdavids/voprf-poc/go/oprf/utils/constants"
 )
 
 // revCmpBit reverses the result of a comparison bit indicator

--- a/go/oprf/utils/conversion.go
+++ b/go/oprf/utils/conversion.go
@@ -3,7 +3,7 @@ package utils
 import (
 	"math/big"
 
-	"github.com/alxdavids/oprf-poc/go/oerr"
+	"github.com/alxdavids/voprf-poc/go/oerr"
 )
 
 // I2osp converts an integer to an octet-string

--- a/go/server/server.go
+++ b/go/server/server.go
@@ -8,10 +8,10 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/alxdavids/oprf-poc/go/jsonrpc"
-	"github.com/alxdavids/oprf-poc/go/oerr"
-	"github.com/alxdavids/oprf-poc/go/oprf"
-	gg "github.com/alxdavids/oprf-poc/go/oprf/groups"
+	"github.com/alxdavids/voprf-poc/go/jsonrpc"
+	"github.com/alxdavids/voprf-poc/go/oerr"
+	"github.com/alxdavids/voprf-poc/go/oprf"
+	gg "github.com/alxdavids/voprf-poc/go/oprf/groups"
 )
 
 // Config corresponds to the actual HTTP instantiation of the server in the OPRF

--- a/go/server/server_test.go
+++ b/go/server/server_test.go
@@ -5,10 +5,10 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/alxdavids/oprf-poc/go/jsonrpc"
-	"github.com/alxdavids/oprf-poc/go/oerr"
-	gg "github.com/alxdavids/oprf-poc/go/oprf/groups"
-	"github.com/alxdavids/oprf-poc/go/oprf/groups/ecgroup"
+	"github.com/alxdavids/voprf-poc/go/jsonrpc"
+	"github.com/alxdavids/voprf-poc/go/oerr"
+	gg "github.com/alxdavids/voprf-poc/go/oprf/groups"
+	"github.com/alxdavids/voprf-poc/go/oprf/groups/ecgroup"
 	"github.com/stretchr/testify/assert"
 )
 


### PR DESCRIPTION
Updating imports to point to voprf-poc repository. 