### PR TITLE
Add test vectors for hashToCurve

### DIFF
--- a/go/go.mod
+++ b/go/go.mod
@@ -3,7 +3,7 @@ module github.com/alxdavids/voprf-poc/go
 go 1.13
 
 require (
-	github.com/armfazh/h2c-go-ref v0.0.0-20200317222234-b24dd5d7365d
+	github.com/armfazh/h2c-go-ref v0.0.0-20200318224313-763912060962
 	github.com/cloudflare/circl v1.0.0
 	github.com/otrv4/ed448 v0.0.0-20200313043504-efc4accd8117
 	github.com/stretchr/testify v1.4.0

--- a/go/go.mod
+++ b/go/go.mod
@@ -3,11 +3,10 @@ module github.com/alxdavids/voprf-poc/go
 go 1.13
 
 require (
-	github.com/armfazh/h2c-go-ref v0.0.0-20200129021002-7dd661fbab09
-	github.com/armfazh/tozan-ecc v0.0.0-20200204225737-c3304615766b // indirect
+	github.com/armfazh/h2c-go-ref v0.0.0-20200317222234-b24dd5d7365d
 	github.com/cloudflare/circl v1.0.0
 	github.com/otrv4/ed448 v0.0.0-20200313043504-efc4accd8117
 	github.com/stretchr/testify v1.4.0
-	golang.org/x/crypto v0.0.0-20200311171314-f7b00557c8c4
-	golang.org/x/sys v0.0.0-20200302150141-5c8b2ff67527 // indirect
+	golang.org/x/crypto v0.0.0-20200317142112-1b76d66859c6
+	golang.org/x/sys v0.0.0-20200317113312-5766fd39f98d // indirect
 )

--- a/go/go.sum
+++ b/go/go.sum
@@ -3,6 +3,10 @@ github.com/agl/ed25519 v0.0.0-20170116200512-5312a6153412 h1:w1UutsfOrms1J05zt7I
 github.com/agl/ed25519 v0.0.0-20170116200512-5312a6153412/go.mod h1:WPjqKcmVOxf0XSf3YxCJs6N6AOSrOx3obionmG7T0y0=
 github.com/armfazh/h2c-go-ref v0.0.0-20200129021002-7dd661fbab09 h1:dbeOnT4BD46K62Wq2M2qaJzRD23z9MpFAEJ2i4xBLFA=
 github.com/armfazh/h2c-go-ref v0.0.0-20200129021002-7dd661fbab09/go.mod h1:ovlWq/CllkrlsufhQEj4UnESVpnDNqgK1ZgHRmBcgdM=
+github.com/armfazh/h2c-go-ref v0.0.0-20200204230903-312601b41b9e h1:TeTy1JrwxvuC5M2oyWOHKTM+VvxuT3u2EObwHRy9cFA=
+github.com/armfazh/h2c-go-ref v0.0.0-20200204230903-312601b41b9e/go.mod h1:R6C2MGYPfQ62R2aYayo3gBdHOyoH0DBqnSGIPG/zAQI=
+github.com/armfazh/h2c-go-ref v0.0.0-20200317222234-b24dd5d7365d h1:SDuo+VqdRANEnoRMzuQeTr1vzevRGlh49WnWcq22pGA=
+github.com/armfazh/h2c-go-ref v0.0.0-20200317222234-b24dd5d7365d/go.mod h1:R6C2MGYPfQ62R2aYayo3gBdHOyoH0DBqnSGIPG/zAQI=
 github.com/armfazh/tozan-ecc v0.0.0-20200128002259-3fa3a558a3f8/go.mod h1:u25eZC5Z8uJFQxJxGBz1Blfii/7m3DfmwX0vFnwtG9I=
 github.com/armfazh/tozan-ecc v0.0.0-20200204225737-c3304615766b h1:hQde6c4IclpQnZQugu/HodsOqAZRpoTPHktL58keRQg=
 github.com/armfazh/tozan-ecc v0.0.0-20200204225737-c3304615766b/go.mod h1:u25eZC5Z8uJFQxJxGBz1Blfii/7m3DfmwX0vFnwtG9I=
@@ -40,6 +44,8 @@ golang.org/x/crypto v0.0.0-20200117160349-530e935923ad h1:Jh8cai0fqIK+f6nG0UgPW5
 golang.org/x/crypto v0.0.0-20200117160349-530e935923ad/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200311171314-f7b00557c8c4 h1:QmwruyY+bKbDDL0BaglrbZABEali68eoMFhTZpCjYVA=
 golang.org/x/crypto v0.0.0-20200311171314-f7b00557c8c4/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
+golang.org/x/crypto v0.0.0-20200317142112-1b76d66859c6 h1:TjszyFsQsyZNHwdVdZ5m7bjmreu0znc2kRYsEml9/Ww=
+golang.org/x/crypto v0.0.0-20200317142112-1b76d66859c6/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/lint v0.0.0-20191125180803-fdd1cda4f05f/go.mod h1:5qLYkcX4OjUUV8bRuDixDT3tpyyb+LUpUlRWLxfhWrs=
 golang.org/x/mod v0.0.0-20190513183733-4bf6d317e70e/go.mod h1:mXi4GBBbnImb6dmsKGUJ2LatrhH/nqhxcFungHvyanc=
 golang.org/x/mod v0.1.1-0.20191105210325-c90efee705ee/go.mod h1:QqPTAvyqsEbceGzBzNggFXnrqF1CaUcvgkdR5Ot7KZg=
@@ -59,6 +65,8 @@ golang.org/x/sys v0.0.0-20200124204421-9fbb57f87de9 h1:1/DFK4b7JH8DmkqhUk48onnSf
 golang.org/x/sys v0.0.0-20200124204421-9fbb57f87de9/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200302150141-5c8b2ff67527 h1:uYVVQ9WP/Ds2ROhcaGPeIdVq0RIXVLwsHlnvJ+cT1So=
 golang.org/x/sys v0.0.0-20200302150141-5c8b2ff67527/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200317113312-5766fd39f98d h1:62ap6LNOjDU6uGmKXHJbSfciMoV+FeI1sRXx/pLDL44=
+golang.org/x/sys v0.0.0-20200317113312-5766fd39f98d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/tools v0.0.0-20190621195816-6e04913cbbac/go.mod h1:/rFqwRUd4F7ZHNgwSSTFct+R/Kf4OFW1sUzUTQQTgfc=
 golang.org/x/tools v0.0.0-20191017151554-a3bc800455d5/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=

--- a/go/go.sum
+++ b/go/go.sum
@@ -7,9 +7,13 @@ github.com/armfazh/h2c-go-ref v0.0.0-20200204230903-312601b41b9e h1:TeTy1JrwxvuC
 github.com/armfazh/h2c-go-ref v0.0.0-20200204230903-312601b41b9e/go.mod h1:R6C2MGYPfQ62R2aYayo3gBdHOyoH0DBqnSGIPG/zAQI=
 github.com/armfazh/h2c-go-ref v0.0.0-20200317222234-b24dd5d7365d h1:SDuo+VqdRANEnoRMzuQeTr1vzevRGlh49WnWcq22pGA=
 github.com/armfazh/h2c-go-ref v0.0.0-20200317222234-b24dd5d7365d/go.mod h1:R6C2MGYPfQ62R2aYayo3gBdHOyoH0DBqnSGIPG/zAQI=
+github.com/armfazh/h2c-go-ref v0.0.0-20200318224313-763912060962 h1:j5zM1qsdf7P+ahT2mvz7ZzqtvyO5DLy0PPxZTyD7d9w=
+github.com/armfazh/h2c-go-ref v0.0.0-20200318224313-763912060962/go.mod h1:c+M7p/g/wcOuA3JL3iSovqQzuGPKey72kVfLIJkSsko=
 github.com/armfazh/tozan-ecc v0.0.0-20200128002259-3fa3a558a3f8/go.mod h1:u25eZC5Z8uJFQxJxGBz1Blfii/7m3DfmwX0vFnwtG9I=
 github.com/armfazh/tozan-ecc v0.0.0-20200204225737-c3304615766b h1:hQde6c4IclpQnZQugu/HodsOqAZRpoTPHktL58keRQg=
 github.com/armfazh/tozan-ecc v0.0.0-20200204225737-c3304615766b/go.mod h1:u25eZC5Z8uJFQxJxGBz1Blfii/7m3DfmwX0vFnwtG9I=
+github.com/armfazh/tozan-ecc v0.1.0 h1:CqVEdjUATWi09ZDTS5RfP1amGQbEjD7jieD5P39NsBQ=
+github.com/armfazh/tozan-ecc v0.1.0/go.mod h1:u25eZC5Z8uJFQxJxGBz1Blfii/7m3DfmwX0vFnwtG9I=
 github.com/awnumar/memcall v0.0.0-20191004114545-73db50fd9f80/go.mod h1:S911igBPR9CThzd/hYQQmTc9SWNu3ZHIlCGaWsWsoJo=
 github.com/awnumar/memguard v0.21.0/go.mod h1:+ejY3DekvjnDWBXHwL5xB5p4Il77kDsrIz+UOUNrm2Q=
 github.com/cloudflare/circl v1.0.0 h1:64b6pyfCFbYm623ncIkYGNZaOcmIbyd+CjyMi2L9vdI=

--- a/go/oprf/groups/ecgroup/h2c.go
+++ b/go/oprf/groups/ecgroup/h2c.go
@@ -17,7 +17,7 @@ type hasher2point struct {
 }
 
 func (h hasher2point) Hash(msg []byte) (Point, error) {
-	Q := h.HashToPoint.Hash(msg, h.dst)
+	Q := h.HashToPoint.Hash(msg)
 	P := Point{}.New(h.GroupCurve).(Point)
 	X := Q.X().Polynomial()
 	Y := Q.Y().Polynomial()
@@ -36,16 +36,16 @@ func getH2CSuite(gc GroupCurve) (HashToPoint, error) {
 	var err error
 	switch gc.Name() {
 	case "P-384":
-		suite = h2c.P384_SHA512_SSWU_RO_
+		suite = h2c.P384_XMDSHA512_SSWU_RO_
 	case "P-521":
-		suite = h2c.P521_SHA512_SSWU_RO_
+		suite = h2c.P521_XMDSHA512_SSWU_RO_
 	case "curve-448":
-		suite = h2c.Curve448_SHA512_ELL2_RO_
+		suite = h2c.Curve448_XMDSHA512_ELL2_RO_
 	default:
 		return nil, oerr.ErrUnsupportedGroup
 	}
 	dst := append([]byte("RFCXXXX-VOPRF-"), suite...)
-	hasher, err := suite.Get()
+	hasher, err := suite.Get(dst)
 	if err != nil {
 		return nil, err
 	}

--- a/go/oprf/groups/ecgroup/h2c_test.go
+++ b/go/oprf/groups/ecgroup/h2c_test.go
@@ -85,7 +85,6 @@ func performHashToCurve(curve GroupCurve, testVectors hashToCurveTestVectors) er
 		return err
 	}
 	hasherMod := hasher.(hasher2point)
-	hasherMod.dst = []byte("QUUX-V01-CS02")
 	for _, v := range testVectors.Vectors {
 		R, err := hasherMod.Hash([]byte(v.Msg))
 		if err != nil {

--- a/go/oprf/groups/ecgroup/h2c_test.go
+++ b/go/oprf/groups/ecgroup/h2c_test.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"math/big"
-	"os"
 	"strings"
 	"testing"
 )
@@ -46,9 +45,24 @@ func TestHashToCurveP384(t *testing.T) {
 
 func TestHashToCurveP521(t *testing.T) {
 	curve := initCurve(t, "P-521")
-	dir, _ := os.Getwd()
-	fmt.Println(dir)
 	buf, err := ioutil.ReadFile("../../../../test-vectors/hash-to-curve/p521-sha512-sswu-ro-.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	testVectors := hashToCurveTestVectors{}
+	err = json.Unmarshal(buf, &testVectors)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = performHashToCurve(curve, testVectors)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestHashToCurve448(t *testing.T) {
+	curve := initCurve(t, "curve-448")
+	buf, err := ioutil.ReadFile("../../../../test-vectors/hash-to-curve/curve448-sha512-ell2-ro-.json")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/go/oprf/groups/ecgroup/h2c_test.go
+++ b/go/oprf/groups/ecgroup/h2c_test.go
@@ -97,10 +97,10 @@ func performHashToCurve(curve GroupCurve, testVectors hashToCurveTestVectors) er
 		}
 		chkR := Point{X: new(big.Int).SetBytes(expectedX), Y: new(big.Int).SetBytes(expectedY), pog: curve, compress: true}
 		if !R.Equal(chkR) {
-			fmt.Println(x)
-			fmt.Println(y)
-			fmt.Println(hex.EncodeToString(R.X.Bytes()))
-			fmt.Println(hex.EncodeToString(R.Y.Bytes()))
+			fmt.Printf("\n expected X in hex %x \n", x)
+			fmt.Printf("\n expected Y in hex %x \n", y)
+			fmt.Printf("\n X in hex %x \n", hex.EncodeToString(R.X.Bytes()))
+			fmt.Printf("\n Y in hex %x \n", hex.EncodeToString(R.Y.Bytes()))
 			return errors.New("Points are not equal")
 		}
 	}

--- a/test-vectors/hash-to-curve/curve448-sha512-ell2-ro-.json
+++ b/test-vectors/hash-to-curve/curve448-sha512-ell2-ro-.json
@@ -1,0 +1,45 @@
+{
+  "ciphersuite": "curve448-SHA512-ELL2-RO-",
+  "curve": "curve448",
+  "dst": "QUUX-V01-CS02",
+  "field": {
+    "m": "0x1",
+    "p": "0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+  },
+  "hash": "sha512",
+  "map": {
+    "name": "ELL2",
+    "sgn0": "sgn0_le"
+  },
+  "randomOracle": true,
+  "vectors": [
+    {
+      "P": {
+        "x": "0xcac7dc52904b4a89aa84cdc66052d7354218b25b912a7ee2da5281a0962ad6c5ad957bba432c24e06f8da5cbde708685d5760df2d9a029d7",
+        "y": "0xd87ac2253b0e2a41244ca567b7a5a0e082e72ba00272c99cb33aaddae30692436512aa8c2236ed353a617eb2076253331e02400f0b904200"
+      },
+      "msg": ""
+    },
+    {
+      "P": {
+        "x": "0x4aba342179cb6a0d10bf67d50f0442b87be818c6d9873d9c40aea6e50319d808f32f0d41ff2ba19f6c5d881577ee9a362e139015d12629c7",
+        "y": "0x7e801613ee1a3acf6964f41e7c2711804c8b178df6015c7be0e0f18c153a382e9497d521c14b321a8f9ac026f9ba5303cac37fd32c71fd9f"
+      },
+      "msg": "abc "
+    },
+    {
+      "P": {
+        "x": "0x3373de58220e9a7fcdfc5abd714f7bdd5d6fbd77b30747acdc8d04a0640664921daf7334745358fe7be664a2295ae72596bd4eea646d79e8",
+        "y": "0xb248b268afcd6b03057c720cbdb3ab6f377afd5fe46a682bbeef6a80717971e2a2223b166ce43e55642a707a6e7bbd955c78d1d62ef3e7ea"
+      },
+      "msg": "abcdef0123456789"
+    },
+    {
+      "P": {
+        "x": "0x43cbaabc5e9f7535f9545ceaf44362da26f4ac8ef402c43635d604752f519214038805411ef4a02e8b41c253c54f7cc4a20d50054cae7070",
+        "y": "0x0e8372deed030a635f492e3a62cb437a3040377bda8ba049f8d08a06e1a9ddb29bffe06f4e078b45d789768f68556d8a325ad9d6ea28bd58"
+      },
+      "msg": "a512_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    }
+  ]
+}

--- a/test-vectors/hash-to-curve/curve448-sha512-ell2-ro-.json
+++ b/test-vectors/hash-to-curve/curve448-sha512-ell2-ro-.json
@@ -1,7 +1,6 @@
 {
   "ciphersuite": "curve448-SHA512-ELL2-RO-",
   "curve": "curve448",
-  "dst": "QUUX-V01-CS02",
   "field": {
     "m": "0x1",
     "p": "0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffffffffffffffffffffffffffffffffffffffffffffffffffff"

--- a/test-vectors/hash-to-curve/p384-sha512-sswu-ro-.json
+++ b/test-vectors/hash-to-curve/p384-sha512-sswu-ro-.json
@@ -15,29 +15,29 @@
   "vectors": [
     {
       "P": {
-        "x": "0x6aede0bbf8f498a3eaefa55ff5b619d3006a3911ae3d398c8821e31a248fd85239a83f6c536b77f73e686ed97ecd1111",
-        "y": "0xc27e713458ebfd377bdd81a9a73d800d4f6769b0e8ddf9369ef84a91536aa1f29a60dc7c5a9765a44b56951d91797f13"
+        "x": "0xe25b84fe1105da5084c2ea5855ff45cc25f6fad7012d177745b9e120bfad80a8f5285e12cb39c9d3ce1088dffb4a57f1",
+        "y": "0xf0afd801e4df9cc55ae61bb7ea5abf2f46e886aa048f873ca481087aa8679015da7e2b24ec9d9506d169b3da2277c29f"
       },
       "msg": ""
     },
     {
       "P": {
-        "x": "0x49015966ac2870aa1854378f4ec030458520d38519e61d682586291f9e005de4587acf000a71b44bbe98eb0dd4790ddb",
-        "y": "0x7ed595efc7282bc8c4c1641067a1585b5b20eb9754832025dc76e78856de6ad7d00fa8adca343fcdf37fe5fe6298e4c2"
+        "x": "0x142c4eb59bc36dd7cff9106428aea70180b9bce3656a443c23a20656ae03079d332d4bebb4bdd3bb818e7b3d940723f6",
+        "y": "0x0b09a357caa3ee5662c8414278306cb8a629b44003dea3ddca5ad7903a09862c997d837d872edf9b428cf3e640be1c5c"
       },
       "msg": "abc"
     },
     {
       "P": {
-        "x": "0xd9b4cc421f6998172fad86aa499f530ad7967df6609db6640fcc1b816b4f9acd685ad2c0d3dc1b75160742ecc1eafd08",
-        "y": "0xb5f0e185ad76df45b9cea1e7bd78458b9cb1a23f5cb918a7652d0d716d8bbad95c1a473de3a0180a0c3d496840d2d0a2"
+        "x": "0xba9b0a13f61459216fbc708d289c0f1aa27f6a215f230fd5863d0b5148ae4bccd34762119cee24bc08575ddcacbd0be6",
+        "y": "0x65e767c72b1190725f1b4ab1e32ed19df6d3e6b0c8ca18608f44a78ccba690e610e8c0b82a489bf37e04002204db3254"
       },
       "msg": "abcdef0123456789"
     },
     {
       "P": {
-        "x": "0x481a6d76117ab5eed13d28aa16166d09da3a3e5adc341829247385520fbd42a65132eba21f70887dfb3bbc0a482a1088",
-        "y": "0x969416fd238f3e0c6617f6c89efac5ace2238445ca78349f3bc802d64eb084833dddbee66c703a5de3d44daaa632a8a4"
+        "x": "0x26d18bb915424ad0332605d57ee2f09da9445e470ed5fc76259e6f099159670e00093beebcd876359ddc36772f3ad908",
+        "y": "0x7ed91b95b4d00c84e90cc1054a0eaff998d14383759e63d14333e6e3ee608f60dcacc2b8a6dad66a986caf90f90dbe98"
       },
       "msg": "a512_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
     }

--- a/test-vectors/hash-to-curve/p384-sha512-sswu-ro-.json
+++ b/test-vectors/hash-to-curve/p384-sha512-sswu-ro-.json
@@ -1,7 +1,6 @@
 {
   "ciphersuite": "P384-SHA512-SSWU-RO-",
   "curve": "P384",
-  "dst": "QUUX-V01-CS02",
   "field": {
     "m": "0x1",
     "p": "0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffff0000000000000000ffffffff"

--- a/test-vectors/hash-to-curve/p521-sha512-sswu-ro-.json
+++ b/test-vectors/hash-to-curve/p521-sha512-sswu-ro-.json
@@ -15,29 +15,29 @@
   "vectors": [
     {
       "P": {
-        "x": "0x000db5ae86c4a7ca7fb8c4588db0dec222d2220183a0d98ba9e9ab1f43955a8b27e3bc864facc4d199d8466ea8e6c0d1c41a6468a2a227bc71ef9685f2ccbc539cdd",
-        "y": "0x01d4487d9408b58ff71fea536f6761a8e1d3a851932fbd2706ca473e82bd494b92845cd4e3353fe5ff8a6b6200a3288bf5f76e962ef6297ba17a8d29540fa4ad78d3"
+        "x": "0x0103316d2d67cbecf2d201899c304aa30cb8670872bf612ef322b79b6fdf56190762c9471a28400c93f4c093f37ea24efc9b0dc5280cacd7e7defe5cc253b02b0232",
+        "y": "0x016d573660ff80fdd75aacd2acc30e604a0804f47475bf5fe60c9752db874593c0691ce13a0b72891313d3c4f69a5a0bae1d1cfaecc92dc1efd4a13c0c4802bbf0a3"
       },
       "msg": ""
     },
     {
       "P": {
-        "x": "0x0087eade308789ef88d2463366d6eef8f3389b8cc01ef4ed30e32d09ace10f870e86038de04e1995967c821861fe85783ceca67063f7b06fc404e0662a18b3e48ac0",
-        "y": "0x01a83d54da03146c442182ccc976e9e1da2424f23d158c5c12c6bda3b250b66d6305b152a39d1fdca940f17d046cd2117aac731b9996d56e0ebfeb9266e425273666"
+        "x": "0x8def53b7430a9ce8675ac5e05713bdf9040df0c286bdaddbcb650c857ecfd72a4a75c157fd741a3d5709df3e18d3a871a09b9adfc64a9d3158979ba56a003f64ae",
+        "y": "0xc0e37cc0f54d815a389b9d347f547b899969d7dc8297c4be54a94883c03e845b9d4655f6bddcaf373477f580d84c7a9c84215fc6e0a98745b24364ce0627345077"
       },
       "msg": "abc"
     },
     {
       "P": {
-        "x": "0x0124a71e5274f09d098fe4d0b89a0ed673275293a35d65ec38a0bf18b3c5c249a91d0538e3804aecb68f2e05182935e28b33da9ac58ba837a2c7623c321477ee8fa1",
-        "y": "0x011f560aa421178ffddb2df1b015f296640ab22a8c782aed4850673ad25f86d230f0fd9404bad6936b3ad3a86ef12888eaf18a2870b405e8fd1d2d728deef43769ec"
+        "x": "0x0124976a95055c82c05994b7df90d9e20bcd7042bf4d74d68a98105aee97f0addfb4ca1de461190fed803b9f004856f604e9c2a8be4b2b11e57af09a0aadf9c77bc9",
+        "y": "0x010600cc2794268d2170b881afa13a6092fc5d0192831db8612b127495c691b2cf954ca802d55817f639034847c440f46215b7c3cdf3bd7f062ed4ce8306bfaf8c1a"
       },
       "msg": "abcdef0123456789"
     },
     {
       "P": {
-        "x": "0x0063b4f545c951c9be623ed6cb1adb51d181ec8a603d8f2430f5853ecfe98ee4bcb624ef6c51167f95ce5d95e70731f3f506e778f5f0cce7524bb562fedb496eddeb",
-        "y": "0x014831a46b2f77eb8737844e8079d3707d2b6a6a7ecff7f1a3986bcfa62b1edc1de8098641f945f3ab8a5fbdcf53c3c71021962d35b6bfeaae1012dd577c1b45f15a"
+        "x": "0x0174e25e6d0708aaf97f6f0639968876db28e391094be19ce79d30a01badcf753090e6274d47ed0dce3bd9bcf4389d8833c8a6cc8678ca08fe7738fde388d7bcde22",
+        "y": "0x0180c60d931a965f44892436be0381a3ecce638a24c11e954d8c1f4224394e32294d318e21711f84eacee8be9e4578b70ca92d2ea8c897bff5776b1f720d3b0ca237"
       },
       "msg": "a512_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
     }

--- a/test-vectors/hash-to-curve/p521-sha512-sswu-ro-.json
+++ b/test-vectors/hash-to-curve/p521-sha512-sswu-ro-.json
@@ -1,7 +1,6 @@
 {
   "ciphersuite": "P521-SHA512-SSWU-RO-",
   "curve": "P384",
-  "dst": "QUUX-V01-CS02",
   "field": {
     "m": "0x1",
     "p": "0x1ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"


### PR DESCRIPTION
This:

- Updates the mod to the latest version of `armfazh/h2c-go-ref`.
- Adds test vectors for hashToCurve for p384, p521 and curve448. These test vectors are generated by running  `armfazh/h2c-go-ref` with the `dst` established on the repo.

This probably needs to be integrated after pull request 26.